### PR TITLE
Add Java job portal API example

### DIFF
--- a/job-portal-api/.gitignore
+++ b/job-portal-api/.gitignore
@@ -1,0 +1,2 @@
+target/
+uploads/

--- a/job-portal-api/README.md
+++ b/job-portal-api/README.md
@@ -1,0 +1,22 @@
+# Job Portal API (Spring Boot)
+
+This is a minimal example of a job portal REST API using Spring Boot. It demonstrates basic CRUD functionality for users, job listings, categories, notifications and file uploads. The application uses an in-memory H2 database and exposes OpenAPI documentation via Swagger UI.
+
+## Features
+
+- User registration and simple basic authentication
+- CRUD endpoints for users, job listings, and job categories
+- Notification retrieval for users
+- File upload and download endpoints
+- In-memory H2 database for quick setup
+- API documentation with springdoc-openapi (Swagger)
+
+## Running
+
+You can build and run the project with Maven:
+
+```bash
+mvn spring-boot:run
+```
+
+Then access the API docs at [http://localhost:8080/swagger-ui.html](http://localhost:8080/swagger-ui.html).

--- a/job-portal-api/pom.xml
+++ b/job-portal-api/pom.xml
@@ -1,0 +1,48 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.example</groupId>
+    <artifactId>job-portal-api</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.1.0</version>
+        <relativePath/> <!-- lookup parent from repository -->
+    </parent>
+    <properties>
+        <java.version>17</java.version>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.0.2</version>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/job-portal-api/src/main/java/com/example/jobportal/JobPortalApplication.java
+++ b/job-portal-api/src/main/java/com/example/jobportal/JobPortalApplication.java
@@ -1,0 +1,11 @@
+package com.example.jobportal;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class JobPortalApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(JobPortalApplication.class, args);
+    }
+}

--- a/job-portal-api/src/main/java/com/example/jobportal/config/SecurityConfig.java
+++ b/job-portal-api/src/main/java/com/example/jobportal/config/SecurityConfig.java
@@ -1,0 +1,36 @@
+package com.example.jobportal.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig {
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http.csrf().disable()
+            .authorizeHttpRequests(auth -> auth.anyRequest().authenticated())
+            .httpBasic();
+        return http.build();
+    }
+
+    @Bean
+    public InMemoryUserDetailsManager userDetailsService(PasswordEncoder encoder) {
+        UserDetails user = User.withUsername("user")
+                .password(encoder.encode("password"))
+                .roles("USER")
+                .build();
+        return new InMemoryUserDetailsManager(user);
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/job-portal-api/src/main/java/com/example/jobportal/controller/FileController.java
+++ b/job-portal-api/src/main/java/com/example/jobportal/controller/FileController.java
@@ -1,0 +1,36 @@
+package com.example.jobportal.controller;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+@RestController
+@RequestMapping("/api/files")
+public class FileController {
+    private final Path root = Paths.get("uploads");
+
+    public FileController() throws IOException {
+        Files.createDirectories(root);
+    }
+
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<String> upload(@RequestParam("file") MultipartFile file) throws IOException {
+        Files.copy(file.getInputStream(), root.resolve(file.getOriginalFilename()));
+        return ResponseEntity.ok("Uploaded");
+    }
+
+    @GetMapping("/{filename}")
+    public ResponseEntity<byte[]> download(@PathVariable String filename) throws IOException {
+        Path file = root.resolve(filename);
+        return ResponseEntity.ok()
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=" + filename)
+                .body(Files.readAllBytes(file));
+    }
+}

--- a/job-portal-api/src/main/java/com/example/jobportal/controller/JobCategoryController.java
+++ b/job-portal-api/src/main/java/com/example/jobportal/controller/JobCategoryController.java
@@ -1,0 +1,39 @@
+package com.example.jobportal.controller;
+
+import com.example.jobportal.model.JobCategory;
+import com.example.jobportal.service.JobCategoryService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/categories")
+public class JobCategoryController {
+    private final JobCategoryService jobCategoryService;
+
+    public JobCategoryController(JobCategoryService jobCategoryService) {
+        this.jobCategoryService = jobCategoryService;
+    }
+
+    @PostMapping
+    public ResponseEntity<JobCategory> create(@RequestBody JobCategory category) {
+        return ResponseEntity.ok(jobCategoryService.save(category));
+    }
+
+    @GetMapping
+    public List<JobCategory> list() { return jobCategoryService.findAll(); }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<JobCategory> get(@PathVariable Long id) {
+        return jobCategoryService.findById(id)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable Long id) {
+        jobCategoryService.deleteById(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/job-portal-api/src/main/java/com/example/jobportal/controller/JobController.java
+++ b/job-portal-api/src/main/java/com/example/jobportal/controller/JobController.java
@@ -1,0 +1,39 @@
+package com.example.jobportal.controller;
+
+import com.example.jobportal.model.JobListing;
+import com.example.jobportal.service.JobService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/jobs")
+public class JobController {
+    private final JobService jobService;
+
+    public JobController(JobService jobService) {
+        this.jobService = jobService;
+    }
+
+    @PostMapping
+    public ResponseEntity<JobListing> create(@RequestBody JobListing job) {
+        return ResponseEntity.ok(jobService.save(job));
+    }
+
+    @GetMapping
+    public List<JobListing> list() { return jobService.findAll(); }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<JobListing> get(@PathVariable Long id) {
+        return jobService.findById(id)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable Long id) {
+        jobService.deleteById(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/job-portal-api/src/main/java/com/example/jobportal/controller/NotificationController.java
+++ b/job-portal-api/src/main/java/com/example/jobportal/controller/NotificationController.java
@@ -1,0 +1,27 @@
+package com.example.jobportal.controller;
+
+import com.example.jobportal.model.Notification;
+import com.example.jobportal.service.NotificationService;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/notifications")
+public class NotificationController {
+    private final NotificationService notificationService;
+
+    public NotificationController(NotificationService notificationService) {
+        this.notificationService = notificationService;
+    }
+
+    @PostMapping
+    public Notification create(@RequestBody Notification notification) {
+        return notificationService.save(notification);
+    }
+
+    @GetMapping("/unread/{userId}")
+    public List<Notification> unread(@PathVariable Long userId) {
+        return notificationService.unreadForUser(userId);
+    }
+}

--- a/job-portal-api/src/main/java/com/example/jobportal/controller/UserController.java
+++ b/job-portal-api/src/main/java/com/example/jobportal/controller/UserController.java
@@ -1,0 +1,39 @@
+package com.example.jobportal.controller;
+
+import com.example.jobportal.model.User;
+import com.example.jobportal.service.UserService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/users")
+public class UserController {
+    private final UserService userService;
+
+    public UserController(UserService userService) {
+        this.userService = userService;
+    }
+
+    @PostMapping
+    public ResponseEntity<User> create(@RequestBody User user) {
+        return ResponseEntity.ok(userService.save(user));
+    }
+
+    @GetMapping
+    public List<User> list() { return userService.findAll(); }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<User> get(@PathVariable Long id) {
+        return userService.findById(id)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable Long id) {
+        userService.deleteById(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/job-portal-api/src/main/java/com/example/jobportal/model/JobCategory.java
+++ b/job-portal-api/src/main/java/com/example/jobportal/model/JobCategory.java
@@ -1,0 +1,17 @@
+package com.example.jobportal.model;
+
+import jakarta.persistence.*;
+
+@Entity
+public class JobCategory {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String name;
+
+    // getters and setters
+    public Long getId() {return id;}
+    public void setId(Long id) {this.id = id;}
+    public String getName() {return name;}
+    public void setName(String name) {this.name = name;}
+}

--- a/job-portal-api/src/main/java/com/example/jobportal/model/JobListing.java
+++ b/job-portal-api/src/main/java/com/example/jobportal/model/JobListing.java
@@ -1,0 +1,24 @@
+package com.example.jobportal.model;
+
+import jakarta.persistence.*;
+
+@Entity
+public class JobListing {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String title;
+    private String description;
+    @ManyToOne
+    private JobCategory category;
+
+    // getters and setters
+    public Long getId() {return id;}
+    public void setId(Long id) {this.id = id;}
+    public String getTitle() {return title;}
+    public void setTitle(String title) {this.title = title;}
+    public String getDescription() {return description;}
+    public void setDescription(String description) {this.description = description;}
+    public JobCategory getCategory() {return category;}
+    public void setCategory(JobCategory category) {this.category = category;}
+}

--- a/job-portal-api/src/main/java/com/example/jobportal/model/Notification.java
+++ b/job-portal-api/src/main/java/com/example/jobportal/model/Notification.java
@@ -1,0 +1,24 @@
+package com.example.jobportal.model;
+
+import jakarta.persistence.*;
+
+@Entity
+public class Notification {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String message;
+    @ManyToOne
+    private User user;
+    private boolean read;
+
+    // getters and setters
+    public Long getId() {return id;}
+    public void setId(Long id) {this.id = id;}
+    public String getMessage() {return message;}
+    public void setMessage(String message) {this.message = message;}
+    public User getUser() {return user;}
+    public void setUser(User user) {this.user = user;}
+    public boolean isRead() {return read;}
+    public void setRead(boolean read) {this.read = read;}
+}

--- a/job-portal-api/src/main/java/com/example/jobportal/model/User.java
+++ b/job-portal-api/src/main/java/com/example/jobportal/model/User.java
@@ -1,0 +1,23 @@
+package com.example.jobportal.model;
+
+import jakarta.persistence.*;
+
+@Entity
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String username;
+    private String password;
+    private String email;
+
+    // getters and setters omitted for brevity
+    public Long getId() {return id;}
+    public void setId(Long id) {this.id = id;}
+    public String getUsername() {return username;}
+    public void setUsername(String username) {this.username = username;}
+    public String getPassword() {return password;}
+    public void setPassword(String password) {this.password = password;}
+    public String getEmail() {return email;}
+    public void setEmail(String email) {this.email = email;}
+}

--- a/job-portal-api/src/main/java/com/example/jobportal/repository/JobCategoryRepository.java
+++ b/job-portal-api/src/main/java/com/example/jobportal/repository/JobCategoryRepository.java
@@ -1,0 +1,7 @@
+package com.example.jobportal.repository;
+
+import com.example.jobportal.model.JobCategory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JobCategoryRepository extends JpaRepository<JobCategory, Long> {
+}

--- a/job-portal-api/src/main/java/com/example/jobportal/repository/JobRepository.java
+++ b/job-portal-api/src/main/java/com/example/jobportal/repository/JobRepository.java
@@ -1,0 +1,7 @@
+package com.example.jobportal.repository;
+
+import com.example.jobportal.model.JobListing;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JobRepository extends JpaRepository<JobListing, Long> {
+}

--- a/job-portal-api/src/main/java/com/example/jobportal/repository/NotificationRepository.java
+++ b/job-portal-api/src/main/java/com/example/jobportal/repository/NotificationRepository.java
@@ -1,0 +1,10 @@
+package com.example.jobportal.repository;
+
+import com.example.jobportal.model.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+    List<Notification> findByUserIdAndReadFalse(Long userId);
+}

--- a/job-portal-api/src/main/java/com/example/jobportal/repository/UserRepository.java
+++ b/job-portal-api/src/main/java/com/example/jobportal/repository/UserRepository.java
@@ -1,0 +1,10 @@
+package com.example.jobportal.repository;
+
+import com.example.jobportal.model.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByUsername(String username);
+}

--- a/job-portal-api/src/main/java/com/example/jobportal/service/JobCategoryService.java
+++ b/job-portal-api/src/main/java/com/example/jobportal/service/JobCategoryService.java
@@ -1,0 +1,25 @@
+package com.example.jobportal.service;
+
+import com.example.jobportal.model.JobCategory;
+import com.example.jobportal.repository.JobCategoryRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class JobCategoryService {
+    private final JobCategoryRepository jobCategoryRepository;
+
+    public JobCategoryService(JobCategoryRepository repo) {
+        this.jobCategoryRepository = repo;
+    }
+
+    public JobCategory save(JobCategory category) { return jobCategoryRepository.save(category); }
+
+    public List<JobCategory> findAll() { return jobCategoryRepository.findAll(); }
+
+    public Optional<JobCategory> findById(Long id) { return jobCategoryRepository.findById(id); }
+
+    public void deleteById(Long id) { jobCategoryRepository.deleteById(id); }
+}

--- a/job-portal-api/src/main/java/com/example/jobportal/service/JobService.java
+++ b/job-portal-api/src/main/java/com/example/jobportal/service/JobService.java
@@ -1,0 +1,25 @@
+package com.example.jobportal.service;
+
+import com.example.jobportal.model.JobListing;
+import com.example.jobportal.repository.JobRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class JobService {
+    private final JobRepository jobRepository;
+
+    public JobService(JobRepository jobRepository) {
+        this.jobRepository = jobRepository;
+    }
+
+    public JobListing save(JobListing job) { return jobRepository.save(job); }
+
+    public List<JobListing> findAll() { return jobRepository.findAll(); }
+
+    public Optional<JobListing> findById(Long id) { return jobRepository.findById(id); }
+
+    public void deleteById(Long id) { jobRepository.deleteById(id); }
+}

--- a/job-portal-api/src/main/java/com/example/jobportal/service/NotificationService.java
+++ b/job-portal-api/src/main/java/com/example/jobportal/service/NotificationService.java
@@ -1,0 +1,24 @@
+package com.example.jobportal.service;
+
+import com.example.jobportal.model.Notification;
+import com.example.jobportal.repository.NotificationRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class NotificationService {
+    private final NotificationRepository notificationRepository;
+
+    public NotificationService(NotificationRepository repo) {
+        this.notificationRepository = repo;
+    }
+
+    public Notification save(Notification notification) {
+        return notificationRepository.save(notification);
+    }
+
+    public List<Notification> unreadForUser(Long userId) {
+        return notificationRepository.findByUserIdAndReadFalse(userId);
+    }
+}

--- a/job-portal-api/src/main/java/com/example/jobportal/service/UserService.java
+++ b/job-portal-api/src/main/java/com/example/jobportal/service/UserService.java
@@ -1,0 +1,31 @@
+package com.example.jobportal.service;
+
+import com.example.jobportal.model.User;
+import com.example.jobportal.repository.UserRepository;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class UserService {
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public UserService(UserRepository userRepository, PasswordEncoder passwordEncoder) {
+        this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    public User save(User user) {
+        user.setPassword(passwordEncoder.encode(user.getPassword()));
+        return userRepository.save(user);
+    }
+
+    public List<User> findAll() { return userRepository.findAll(); }
+
+    public Optional<User> findById(Long id) { return userRepository.findById(id); }
+
+    public void deleteById(Long id) { userRepository.deleteById(id); }
+}

--- a/job-portal-api/src/main/resources/application.properties
+++ b/job-portal-api/src/main/resources/application.properties
@@ -1,0 +1,8 @@
+spring.datasource.url=jdbc:h2:mem:jobsdb
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.h2.console.enabled=true
+spring.jpa.hibernate.ddl-auto=update
+springdoc.api-docs.path=/v3/api-docs
+springdoc.swagger-ui.path=/swagger-ui.html

--- a/job-portal-services/README.md
+++ b/job-portal-services/README.md
@@ -1,0 +1,11 @@
+# Job Portal Microservices
+
+This folder contains a basic microservice split of the job portal example. Each service is a standalone Spring Boot application using an H2 in-memory database and Swagger documentation.
+
+## Services
+- **user-service** – manages user registration and CRUD
+- **job-service** – handles job listings and categories
+- **notification-service** – stores and retrieves notifications
+- **file-service** – file upload/download endpoints
+
+Run each service individually with `mvn spring-boot:run` inside its directory.

--- a/job-portal-services/file-service/.gitignore
+++ b/job-portal-services/file-service/.gitignore
@@ -1,0 +1,2 @@
+target/
+uploads/

--- a/job-portal-services/file-service/README.md
+++ b/job-portal-services/file-service/README.md
@@ -1,0 +1,3 @@
+# File Service
+
+Simple microservice for uploading and downloading files. Stores files in a local directory.

--- a/job-portal-services/file-service/pom.xml
+++ b/job-portal-services/file-service/pom.xml
@@ -1,0 +1,48 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.example</groupId>
+    <artifactId>file-service</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.1.0</version>
+        <relativePath/> <!-- lookup parent from repository -->
+    </parent>
+    <properties>
+        <java.version>17</java.version>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.0.2</version>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/job-portal-services/file-service/src/main/java/com/example/fileservice/FileServiceApplication.java
+++ b/job-portal-services/file-service/src/main/java/com/example/fileservice/FileServiceApplication.java
@@ -1,0 +1,11 @@
+package com.example.fileservice;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class FileServiceApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(FileServiceApplication.class, args);
+    }
+}

--- a/job-portal-services/file-service/src/main/java/com/example/fileservice/config/SecurityConfig.java
+++ b/job-portal-services/file-service/src/main/java/com/example/fileservice/config/SecurityConfig.java
@@ -1,0 +1,36 @@
+package com.example.fileservice.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig {
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http.csrf().disable()
+            .authorizeHttpRequests(auth -> auth.anyRequest().authenticated())
+            .httpBasic();
+        return http.build();
+    }
+
+    @Bean
+    public InMemoryUserDetailsManager userDetailsService(PasswordEncoder encoder) {
+        UserDetails user = User.withUsername("user")
+                .password(encoder.encode("password"))
+                .roles("USER")
+                .build();
+        return new InMemoryUserDetailsManager(user);
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/job-portal-services/file-service/src/main/java/com/example/fileservice/controller/FileController.java
+++ b/job-portal-services/file-service/src/main/java/com/example/fileservice/controller/FileController.java
@@ -1,0 +1,36 @@
+package com.example.fileservice.controller;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+@RestController
+@RequestMapping("/api/files")
+public class FileController {
+    private final Path root = Paths.get("uploads");
+
+    public FileController() throws IOException {
+        Files.createDirectories(root);
+    }
+
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<String> upload(@RequestParam("file") MultipartFile file) throws IOException {
+        Files.copy(file.getInputStream(), root.resolve(file.getOriginalFilename()));
+        return ResponseEntity.ok("Uploaded");
+    }
+
+    @GetMapping("/{filename}")
+    public ResponseEntity<byte[]> download(@PathVariable String filename) throws IOException {
+        Path file = root.resolve(filename);
+        return ResponseEntity.ok()
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=" + filename)
+                .body(Files.readAllBytes(file));
+    }
+}

--- a/job-portal-services/file-service/src/main/resources/application.properties
+++ b/job-portal-services/file-service/src/main/resources/application.properties
@@ -1,0 +1,8 @@
+spring.datasource.url=jdbc:h2:mem:jobsdb
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.h2.console.enabled=true
+spring.jpa.hibernate.ddl-auto=update
+springdoc.api-docs.path=/v3/api-docs
+springdoc.swagger-ui.path=/swagger-ui.html

--- a/job-portal-services/job-service/.gitignore
+++ b/job-portal-services/job-service/.gitignore
@@ -1,0 +1,2 @@
+target/
+uploads/

--- a/job-portal-services/job-service/README.md
+++ b/job-portal-services/job-service/README.md
@@ -1,0 +1,3 @@
+# Job Service
+
+Handles CRUD operations for job listings and categories. Swagger UI and H2 database configured for quick testing.

--- a/job-portal-services/job-service/pom.xml
+++ b/job-portal-services/job-service/pom.xml
@@ -1,0 +1,48 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.example</groupId>
+    <artifactId>job-service</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.1.0</version>
+        <relativePath/> <!-- lookup parent from repository -->
+    </parent>
+    <properties>
+        <java.version>17</java.version>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.0.2</version>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/job-portal-services/job-service/src/main/java/com/example/jobservice/JobServiceApplication.java
+++ b/job-portal-services/job-service/src/main/java/com/example/jobservice/JobServiceApplication.java
@@ -1,0 +1,11 @@
+package com.example.jobservice;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class JobServiceApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(JobServiceApplication.class, args);
+    }
+}

--- a/job-portal-services/job-service/src/main/java/com/example/jobservice/config/SecurityConfig.java
+++ b/job-portal-services/job-service/src/main/java/com/example/jobservice/config/SecurityConfig.java
@@ -1,0 +1,36 @@
+package com.example.jobservice.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig {
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http.csrf().disable()
+            .authorizeHttpRequests(auth -> auth.anyRequest().authenticated())
+            .httpBasic();
+        return http.build();
+    }
+
+    @Bean
+    public InMemoryUserDetailsManager userDetailsService(PasswordEncoder encoder) {
+        UserDetails user = User.withUsername("user")
+                .password(encoder.encode("password"))
+                .roles("USER")
+                .build();
+        return new InMemoryUserDetailsManager(user);
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/job-portal-services/job-service/src/main/java/com/example/jobservice/controller/JobCategoryController.java
+++ b/job-portal-services/job-service/src/main/java/com/example/jobservice/controller/JobCategoryController.java
@@ -1,0 +1,39 @@
+package com.example.jobservice.controller;
+
+import com.example.jobservice.model.JobCategory;
+import com.example.jobservice.service.JobCategoryService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/categories")
+public class JobCategoryController {
+    private final JobCategoryService jobCategoryService;
+
+    public JobCategoryController(JobCategoryService jobCategoryService) {
+        this.jobCategoryService = jobCategoryService;
+    }
+
+    @PostMapping
+    public ResponseEntity<JobCategory> create(@RequestBody JobCategory category) {
+        return ResponseEntity.ok(jobCategoryService.save(category));
+    }
+
+    @GetMapping
+    public List<JobCategory> list() { return jobCategoryService.findAll(); }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<JobCategory> get(@PathVariable Long id) {
+        return jobCategoryService.findById(id)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable Long id) {
+        jobCategoryService.deleteById(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/job-portal-services/job-service/src/main/java/com/example/jobservice/controller/JobController.java
+++ b/job-portal-services/job-service/src/main/java/com/example/jobservice/controller/JobController.java
@@ -1,0 +1,39 @@
+package com.example.jobservice.controller;
+
+import com.example.jobservice.model.JobListing;
+import com.example.jobservice.service.JobService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/jobs")
+public class JobController {
+    private final JobService jobService;
+
+    public JobController(JobService jobService) {
+        this.jobService = jobService;
+    }
+
+    @PostMapping
+    public ResponseEntity<JobListing> create(@RequestBody JobListing job) {
+        return ResponseEntity.ok(jobService.save(job));
+    }
+
+    @GetMapping
+    public List<JobListing> list() { return jobService.findAll(); }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<JobListing> get(@PathVariable Long id) {
+        return jobService.findById(id)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable Long id) {
+        jobService.deleteById(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/job-portal-services/job-service/src/main/java/com/example/jobservice/model/JobCategory.java
+++ b/job-portal-services/job-service/src/main/java/com/example/jobservice/model/JobCategory.java
@@ -1,0 +1,17 @@
+package com.example.jobservice.model;
+
+import jakarta.persistence.*;
+
+@Entity
+public class JobCategory {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String name;
+
+    // getters and setters
+    public Long getId() {return id;}
+    public void setId(Long id) {this.id = id;}
+    public String getName() {return name;}
+    public void setName(String name) {this.name = name;}
+}

--- a/job-portal-services/job-service/src/main/java/com/example/jobservice/model/JobListing.java
+++ b/job-portal-services/job-service/src/main/java/com/example/jobservice/model/JobListing.java
@@ -1,0 +1,24 @@
+package com.example.jobservice.model;
+
+import jakarta.persistence.*;
+
+@Entity
+public class JobListing {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String title;
+    private String description;
+    @ManyToOne
+    private JobCategory category;
+
+    // getters and setters
+    public Long getId() {return id;}
+    public void setId(Long id) {this.id = id;}
+    public String getTitle() {return title;}
+    public void setTitle(String title) {this.title = title;}
+    public String getDescription() {return description;}
+    public void setDescription(String description) {this.description = description;}
+    public JobCategory getCategory() {return category;}
+    public void setCategory(JobCategory category) {this.category = category;}
+}

--- a/job-portal-services/job-service/src/main/java/com/example/jobservice/repository/JobCategoryRepository.java
+++ b/job-portal-services/job-service/src/main/java/com/example/jobservice/repository/JobCategoryRepository.java
@@ -1,0 +1,7 @@
+package com.example.jobservice.repository;
+
+import com.example.jobservice.model.JobCategory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JobCategoryRepository extends JpaRepository<JobCategory, Long> {
+}

--- a/job-portal-services/job-service/src/main/java/com/example/jobservice/repository/JobRepository.java
+++ b/job-portal-services/job-service/src/main/java/com/example/jobservice/repository/JobRepository.java
@@ -1,0 +1,7 @@
+package com.example.jobservice.repository;
+
+import com.example.jobservice.model.JobListing;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JobRepository extends JpaRepository<JobListing, Long> {
+}

--- a/job-portal-services/job-service/src/main/java/com/example/jobservice/service/JobCategoryService.java
+++ b/job-portal-services/job-service/src/main/java/com/example/jobservice/service/JobCategoryService.java
@@ -1,0 +1,25 @@
+package com.example.jobservice.service;
+
+import com.example.jobservice.model.JobCategory;
+import com.example.jobservice.repository.JobCategoryRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class JobCategoryService {
+    private final JobCategoryRepository jobCategoryRepository;
+
+    public JobCategoryService(JobCategoryRepository repo) {
+        this.jobCategoryRepository = repo;
+    }
+
+    public JobCategory save(JobCategory category) { return jobCategoryRepository.save(category); }
+
+    public List<JobCategory> findAll() { return jobCategoryRepository.findAll(); }
+
+    public Optional<JobCategory> findById(Long id) { return jobCategoryRepository.findById(id); }
+
+    public void deleteById(Long id) { jobCategoryRepository.deleteById(id); }
+}

--- a/job-portal-services/job-service/src/main/java/com/example/jobservice/service/JobService.java
+++ b/job-portal-services/job-service/src/main/java/com/example/jobservice/service/JobService.java
@@ -1,0 +1,25 @@
+package com.example.jobservice.service;
+
+import com.example.jobservice.model.JobListing;
+import com.example.jobservice.repository.JobRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class JobService {
+    private final JobRepository jobRepository;
+
+    public JobService(JobRepository jobRepository) {
+        this.jobRepository = jobRepository;
+    }
+
+    public JobListing save(JobListing job) { return jobRepository.save(job); }
+
+    public List<JobListing> findAll() { return jobRepository.findAll(); }
+
+    public Optional<JobListing> findById(Long id) { return jobRepository.findById(id); }
+
+    public void deleteById(Long id) { jobRepository.deleteById(id); }
+}

--- a/job-portal-services/job-service/src/main/resources/application.properties
+++ b/job-portal-services/job-service/src/main/resources/application.properties
@@ -1,0 +1,8 @@
+spring.datasource.url=jdbc:h2:mem:jobsdb
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.h2.console.enabled=true
+spring.jpa.hibernate.ddl-auto=update
+springdoc.api-docs.path=/v3/api-docs
+springdoc.swagger-ui.path=/swagger-ui.html

--- a/job-portal-services/notification-service/.gitignore
+++ b/job-portal-services/notification-service/.gitignore
@@ -1,0 +1,2 @@
+target/
+uploads/

--- a/job-portal-services/notification-service/README.md
+++ b/job-portal-services/notification-service/README.md
@@ -1,0 +1,3 @@
+# Notification Service
+
+Provides endpoints to create and fetch user notifications. Uses H2 database and is documented with Swagger.

--- a/job-portal-services/notification-service/pom.xml
+++ b/job-portal-services/notification-service/pom.xml
@@ -1,0 +1,48 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.example</groupId>
+    <artifactId>notification-service</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.1.0</version>
+        <relativePath/> <!-- lookup parent from repository -->
+    </parent>
+    <properties>
+        <java.version>17</java.version>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.0.2</version>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/job-portal-services/notification-service/src/main/java/com/example/notificationservice/NotificationServiceApplication.java
+++ b/job-portal-services/notification-service/src/main/java/com/example/notificationservice/NotificationServiceApplication.java
@@ -1,0 +1,11 @@
+package com.example.notificationservice;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class NotificationServiceApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(NotificationServiceApplication.class, args);
+    }
+}

--- a/job-portal-services/notification-service/src/main/java/com/example/notificationservice/config/SecurityConfig.java
+++ b/job-portal-services/notification-service/src/main/java/com/example/notificationservice/config/SecurityConfig.java
@@ -1,0 +1,36 @@
+package com.example.notificationservice.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig {
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http.csrf().disable()
+            .authorizeHttpRequests(auth -> auth.anyRequest().authenticated())
+            .httpBasic();
+        return http.build();
+    }
+
+    @Bean
+    public InMemoryUserDetailsManager userDetailsService(PasswordEncoder encoder) {
+        UserDetails user = User.withUsername("user")
+                .password(encoder.encode("password"))
+                .roles("USER")
+                .build();
+        return new InMemoryUserDetailsManager(user);
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/job-portal-services/notification-service/src/main/java/com/example/notificationservice/controller/NotificationController.java
+++ b/job-portal-services/notification-service/src/main/java/com/example/notificationservice/controller/NotificationController.java
@@ -1,0 +1,27 @@
+package com.example.notificationservice.controller;
+
+import com.example.notificationservice.model.Notification;
+import com.example.notificationservice.service.NotificationService;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/notifications")
+public class NotificationController {
+    private final NotificationService notificationService;
+
+    public NotificationController(NotificationService notificationService) {
+        this.notificationService = notificationService;
+    }
+
+    @PostMapping
+    public Notification create(@RequestBody Notification notification) {
+        return notificationService.save(notification);
+    }
+
+    @GetMapping("/unread/{userId}")
+    public List<Notification> unread(@PathVariable Long userId) {
+        return notificationService.unreadForUser(userId);
+    }
+}

--- a/job-portal-services/notification-service/src/main/java/com/example/notificationservice/model/Notification.java
+++ b/job-portal-services/notification-service/src/main/java/com/example/notificationservice/model/Notification.java
@@ -1,0 +1,24 @@
+package com.example.notificationservice.model;
+
+import jakarta.persistence.*;
+
+@Entity
+public class Notification {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String message;
+    @ManyToOne
+    private User user;
+    private boolean read;
+
+    // getters and setters
+    public Long getId() {return id;}
+    public void setId(Long id) {this.id = id;}
+    public String getMessage() {return message;}
+    public void setMessage(String message) {this.message = message;}
+    public User getUser() {return user;}
+    public void setUser(User user) {this.user = user;}
+    public boolean isRead() {return read;}
+    public void setRead(boolean read) {this.read = read;}
+}

--- a/job-portal-services/notification-service/src/main/java/com/example/notificationservice/repository/NotificationRepository.java
+++ b/job-portal-services/notification-service/src/main/java/com/example/notificationservice/repository/NotificationRepository.java
@@ -1,0 +1,10 @@
+package com.example.notificationservice.repository;
+
+import com.example.notificationservice.model.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+    List<Notification> findByUserIdAndReadFalse(Long userId);
+}

--- a/job-portal-services/notification-service/src/main/java/com/example/notificationservice/service/NotificationService.java
+++ b/job-portal-services/notification-service/src/main/java/com/example/notificationservice/service/NotificationService.java
@@ -1,0 +1,24 @@
+package com.example.notificationservice.service;
+
+import com.example.notificationservice.model.Notification;
+import com.example.notificationservice.repository.NotificationRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class NotificationService {
+    private final NotificationRepository notificationRepository;
+
+    public NotificationService(NotificationRepository repo) {
+        this.notificationRepository = repo;
+    }
+
+    public Notification save(Notification notification) {
+        return notificationRepository.save(notification);
+    }
+
+    public List<Notification> unreadForUser(Long userId) {
+        return notificationRepository.findByUserIdAndReadFalse(userId);
+    }
+}

--- a/job-portal-services/notification-service/src/main/resources/application.properties
+++ b/job-portal-services/notification-service/src/main/resources/application.properties
@@ -1,0 +1,8 @@
+spring.datasource.url=jdbc:h2:mem:jobsdb
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.h2.console.enabled=true
+spring.jpa.hibernate.ddl-auto=update
+springdoc.api-docs.path=/v3/api-docs
+springdoc.swagger-ui.path=/swagger-ui.html

--- a/job-portal-services/user-service/.gitignore
+++ b/job-portal-services/user-service/.gitignore
@@ -1,0 +1,2 @@
+target/
+uploads/

--- a/job-portal-services/user-service/README.md
+++ b/job-portal-services/user-service/README.md
@@ -1,0 +1,3 @@
+# User Service
+
+Spring Boot microservice providing user registration and CRUD endpoints. Uses H2 in-memory database and exposes Swagger UI.

--- a/job-portal-services/user-service/pom.xml
+++ b/job-portal-services/user-service/pom.xml
@@ -1,0 +1,48 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.example</groupId>
+    <artifactId>user-service</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.1.0</version>
+        <relativePath/> <!-- lookup parent from repository -->
+    </parent>
+    <properties>
+        <java.version>17</java.version>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.0.2</version>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/job-portal-services/user-service/src/main/java/com/example/userservice/UserServiceApplication.java
+++ b/job-portal-services/user-service/src/main/java/com/example/userservice/UserServiceApplication.java
@@ -1,0 +1,11 @@
+package com.example.userservice;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class UserServiceApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(UserServiceApplication.class, args);
+    }
+}

--- a/job-portal-services/user-service/src/main/java/com/example/userservice/config/SecurityConfig.java
+++ b/job-portal-services/user-service/src/main/java/com/example/userservice/config/SecurityConfig.java
@@ -1,0 +1,36 @@
+package com.example.userservice.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig {
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http.csrf().disable()
+            .authorizeHttpRequests(auth -> auth.anyRequest().authenticated())
+            .httpBasic();
+        return http.build();
+    }
+
+    @Bean
+    public InMemoryUserDetailsManager userDetailsService(PasswordEncoder encoder) {
+        UserDetails user = User.withUsername("user")
+                .password(encoder.encode("password"))
+                .roles("USER")
+                .build();
+        return new InMemoryUserDetailsManager(user);
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/job-portal-services/user-service/src/main/java/com/example/userservice/controller/UserController.java
+++ b/job-portal-services/user-service/src/main/java/com/example/userservice/controller/UserController.java
@@ -1,0 +1,39 @@
+package com.example.userservice.controller;
+
+import com.example.userservice.model.User;
+import com.example.userservice.service.UserService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/users")
+public class UserController {
+    private final UserService userService;
+
+    public UserController(UserService userService) {
+        this.userService = userService;
+    }
+
+    @PostMapping
+    public ResponseEntity<User> create(@RequestBody User user) {
+        return ResponseEntity.ok(userService.save(user));
+    }
+
+    @GetMapping
+    public List<User> list() { return userService.findAll(); }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<User> get(@PathVariable Long id) {
+        return userService.findById(id)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable Long id) {
+        userService.deleteById(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/job-portal-services/user-service/src/main/java/com/example/userservice/model/User.java
+++ b/job-portal-services/user-service/src/main/java/com/example/userservice/model/User.java
@@ -1,0 +1,23 @@
+package com.example.userservice.model;
+
+import jakarta.persistence.*;
+
+@Entity
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String username;
+    private String password;
+    private String email;
+
+    // getters and setters omitted for brevity
+    public Long getId() {return id;}
+    public void setId(Long id) {this.id = id;}
+    public String getUsername() {return username;}
+    public void setUsername(String username) {this.username = username;}
+    public String getPassword() {return password;}
+    public void setPassword(String password) {this.password = password;}
+    public String getEmail() {return email;}
+    public void setEmail(String email) {this.email = email;}
+}

--- a/job-portal-services/user-service/src/main/java/com/example/userservice/repository/UserRepository.java
+++ b/job-portal-services/user-service/src/main/java/com/example/userservice/repository/UserRepository.java
@@ -1,0 +1,10 @@
+package com.example.userservice.repository;
+
+import com.example.userservice.model.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByUsername(String username);
+}

--- a/job-portal-services/user-service/src/main/java/com/example/userservice/service/UserService.java
+++ b/job-portal-services/user-service/src/main/java/com/example/userservice/service/UserService.java
@@ -1,0 +1,31 @@
+package com.example.userservice.service;
+
+import com.example.userservice.model.User;
+import com.example.userservice.repository.UserRepository;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class UserService {
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public UserService(UserRepository userRepository, PasswordEncoder passwordEncoder) {
+        this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    public User save(User user) {
+        user.setPassword(passwordEncoder.encode(user.getPassword()));
+        return userRepository.save(user);
+    }
+
+    public List<User> findAll() { return userRepository.findAll(); }
+
+    public Optional<User> findById(Long id) { return userRepository.findById(id); }
+
+    public void deleteById(Long id) { userRepository.deleteById(id); }
+}

--- a/job-portal-services/user-service/src/main/resources/application.properties
+++ b/job-portal-services/user-service/src/main/resources/application.properties
@@ -1,0 +1,8 @@
+spring.datasource.url=jdbc:h2:mem:jobsdb
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.h2.console.enabled=true
+spring.jpa.hibernate.ddl-auto=update
+springdoc.api-docs.path=/v3/api-docs
+springdoc.swagger-ui.path=/swagger-ui.html

--- a/spark-pipeline/README.md
+++ b/spark-pipeline/README.md
@@ -1,0 +1,15 @@
+# Spark Course Activity Pipeline
+
+This directory contains a PySpark job for processing user interaction logs on an online learning platform.
+
+## Overview
+
+The `course_activity_job.py` script reads raw JSON logs from `/mnt/events/user_logs.json`, filters relevant events, aggregates the total time users spend per course each day, and writes the result to `/mnt/analytics/course_activity` in Parquet format.
+
+A schema is provided for expected fields. The job uses the `mergeSchema` option in permissive mode so additional unexpected fields in the JSON files are handled without errors.
+
+## Running the Job
+
+```bash
+spark-submit course_activity_job.py
+```

--- a/spark-pipeline/course_activity_job.py
+++ b/spark-pipeline/course_activity_job.py
@@ -1,0 +1,44 @@
+from pyspark.sql import SparkSession
+from pyspark.sql.functions import col, to_date, sum as _sum
+from pyspark.sql.types import StructType, StructField, StringType, TimestampType, IntegerType
+
+
+def main():
+    spark = SparkSession.builder.appName("CourseActivityPipeline").getOrCreate()
+
+    schema = StructType([
+        StructField("user_id", StringType(), True),
+        StructField("event_type", StringType(), True),
+        StructField("timestamp", TimestampType(), True),
+        StructField("course_id", StringType(), True),
+        StructField("duration_minutes", IntegerType(), True),
+    ])
+
+    # mergeSchema allows new fields in the JSON without failing the load
+    raw_df = (
+        spark.read
+        .schema(schema)
+        .option("mode", "PERMISSIVE")
+        .option("mergeSchema", "true")
+        .json("/mnt/events/user_logs.json")
+    )
+
+    filtered_df = (
+        raw_df.filter(col("event_type").isin("lesson_completed", "quiz_attempted"))
+        .filter(col("user_id").isNotNull())
+        .filter(col("course_id").isNotNull())
+        .withColumn("activity_date", to_date(col("timestamp")))
+    )
+
+    result_df = (
+        filtered_df.groupBy("course_id", "activity_date")
+        .agg(_sum("duration_minutes").alias("total_duration_minutes"))
+    )
+
+    result_df.write.mode("overwrite").parquet("/mnt/analytics/course_activity")
+
+    spark.stop()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a `job-portal-api` folder with a minimal Spring Boot project
- include CRUD controllers for users, jobs, categories and notifications
- add file upload and download endpoints
- configure simple in-memory authentication with Spring Security
- use H2 database and expose Swagger documentation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_685a38ce9204832d8d031dec9f4ad5b4